### PR TITLE
Update java openjdk to version 17 to support minecraft version 1.18.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:16.0.1-jdk-slim-buster
+FROM openjdk:17-jdk-slim-buster
 
 ARG DEBIAN_FRONTEND="noninteractive"
 

--- a/app/config/McMyAdmin.conf
+++ b/app/config/McMyAdmin.conf
@@ -1,0 +1,1 @@
+Java.Path=/usr/local/openjdk-17/bin/java


### PR DESCRIPTION
Updates do dockerfile and mcmyadmin config file to support updated openjdk version 17 to enable running minecraft version 1.18.x servers